### PR TITLE
Fix typo preventing custom CSS from being loaded

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,7 @@
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/hyde.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/custom.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}public/css/custom.css">
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->


### PR DESCRIPTION
`site.baseurl` is defined as `/`, leading to the URL to `custom.css` being rendered as `//public/css/custom.css` – `public` the hostname, not `public` the directory.